### PR TITLE
Provide kDoc for iOS

### DIFF
--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
@@ -43,8 +43,7 @@ class SwissTransferInjection {
     private val uploadRepository by lazy { UploadRepository(apiClientProvider) }
 
     /**
-     * Loads the default user account and initializes Realm transfers
-     * for the default user ID defined in the constants.
+     * Loads the default user account and initializes Realm transfers for the default user ID defined in the constants.
      */
     @Throws(Exception::class)
     fun loadDefaultAccount() {

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
@@ -46,6 +46,7 @@ class SwissTransferInjection {
      * Loads the default user account and initializes Realm transfers
      * for the default user ID defined in the constants.
      */
+    @Throws(Exception::class)
     fun loadDefaultAccount() {
         realmProvider.loadRealmTransfers(Constants.DEFAULT_USER_ID)
     }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/utils/Constants.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/utils/Constants.kt
@@ -18,6 +18,6 @@
 
 package com.infomaniak.multiplatform_swisstransfer.utils
 
-object Constants {
+internal object Constants {
     const val DEFAULT_USER_ID = 0
 }

--- a/buildTools/gradle/src/main/kotlin/com/infomaniak/gradle/extensions/KotlinMultiplatformExt.kt
+++ b/buildTools/gradle/src/main/kotlin/com/infomaniak/gradle/extensions/KotlinMultiplatformExt.kt
@@ -63,4 +63,10 @@ internal fun Project.configureKotlinMultiplatform(extension: KotlinMultiplatform
             }
         }
     }
+
+    // Provide documentation with kDoc in Objective-C header
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    compilerOptions {
+        freeCompilerArgs.add("-Xexport-kdoc")
+    }
 }


### PR DESCRIPTION
By default, [KDocs](https://kotlinlang.org/docs/kotlin-doc.html) comments are not translated into corresponding comments when generating an Objective-C header.