### PR TITLE
chore(TransferType): Set `QR Code` as first case

### DIFF
--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/models/TransferType.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/models/TransferType.kt
@@ -18,8 +18,8 @@
 package com.infomaniak.multiplatform_swisstransfer.common.models
 
 enum class TransferType {
-    LINK,
     QR_CODE,
+    LINK,
     PROXIMITY,
     MAIL,
 }


### PR DESCRIPTION
As suggested by @FabianDevel, we should display the QR Code option first, so it should be the first case of the enum