### PR TITLE
fix(InitUploadBody): Correctly encode `recipientsEmails`

### DIFF
--- a/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/models/upload/request/InitUploadBody.kt
+++ b/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/models/upload/request/InitUploadBody.kt
@@ -51,6 +51,6 @@ class InitUploadBody(
         recaptcha = recaptcha,
         language = uploadSession.language.code,
         files = Json.encodeToString(uploadSession.files.mapToList(::UploadFileRequest)),
-        recipientsEmails = uploadSession.recipientsEmails.joinToString(prefix = "[", postfix = "]"),
+        recipientsEmails = Json.encodeToString(uploadSession.recipientsEmails),
     )
 }


### PR DESCRIPTION
Previous code returned the following: `"[someEmail@recipient.com]"`
I hope encoding it with `Json.encodeToString` encodes it like this: `"[\"someEmail@recipient.com\"]"` 🤞 