### PR TITLE
feat: Get author's email token from within KMP when generating a NewUploadSession

### DIFF
--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
@@ -86,7 +86,15 @@ class SwissTransferInjection(
     }
 
     /** A manager used to orchestrate Uploads operations. */
-    val uploadManager by lazy { UploadManager(uploadController, uploadRepository, transferManager, emailLanguageUtils) }
+    val uploadManager by lazy {
+        UploadManager(
+            uploadController,
+            uploadRepository,
+            transferManager,
+            emailLanguageUtils,
+            emailTokensManager,
+        )
+    }
 
     /** An utils to help use shared routes  */
     val sharedApiUrlCreator by lazy { SharedApiUrlCreator(environment, transferController, uploadController) }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/EmailTokensManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/EmailTokensManager.kt
@@ -19,6 +19,7 @@ package com.infomaniak.multiplatform_swisstransfer.managers
 
 import com.infomaniak.multiplatform_swisstransfer.common.exceptions.RealmException
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.EmailTokensController
+import com.infomaniak.multiplatform_swisstransfer.network.models.upload.response.AuthorEmailToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -45,13 +46,13 @@ class EmailTokensManager(private val emailTokensController: EmailTokensControlle
      * Asynchronously sets the email and it's corresponding token.
      *
      * @param email The validated email.
-     * @param token The valid token associated to the email.
+     * @param authorEmailToken The valid token associated to the email.
      *
      * @throws RealmException If an error occurs during database access.
      * @throws CancellationException If the operation is cancelled.
      */
     @Throws(RealmException::class, CancellationException::class)
-    suspend fun setEmailToken(email: String, token: String): Unit = withContext(Dispatchers.IO) {
-        emailTokensController.setEmailToken(email, token)
+    suspend fun setEmailToken(email: String, authorEmailToken: AuthorEmailToken): Unit = withContext(Dispatchers.IO) {
+        emailTokensController.setEmailToken(email, authorEmailToken.token)
     }
 }


### PR DESCRIPTION
Apps don't need to get the `authorEmailToken` manually through the `emailTokensManager` by themselves, the shared KMP code can handle this matter automatically when generating a `NewUploadSession`. 

This PR exposes a new `generateNewUploadSession()` method that needs to be called to get the `NewUploadSession` to pass to `UploadManager`'s `createAndGetUpload()`