### PR TITLE
feat: Automatically handles the authorEmailToken inside KMP

### DIFF
--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
@@ -86,7 +86,15 @@ class SwissTransferInjection(
     }
 
     /** A manager used to orchestrate Uploads operations. */
-    val uploadManager by lazy { UploadManager(uploadController, uploadRepository, transferManager, emailLanguageUtils) }
+    val uploadManager by lazy {
+        UploadManager(
+            uploadController,
+            uploadRepository,
+            transferManager,
+            emailLanguageUtils,
+            emailTokensManager,
+        )
+    }
 
     /** An utils to help use shared routes  */
     val sharedApiUrlCreator by lazy { SharedApiUrlCreator(environment, transferController, uploadController) }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/EmailTokensManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/EmailTokensManager.kt
@@ -19,7 +19,6 @@ package com.infomaniak.multiplatform_swisstransfer.managers
 
 import com.infomaniak.multiplatform_swisstransfer.common.exceptions.RealmException
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.EmailTokensController
-import com.infomaniak.multiplatform_swisstransfer.network.models.upload.response.AuthorEmailToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -46,13 +45,13 @@ class EmailTokensManager(private val emailTokensController: EmailTokensControlle
      * Asynchronously sets the email and it's corresponding token.
      *
      * @param email The validated email.
-     * @param authorEmailToken The valid token associated to the email.
+     * @param emailToken The valid token associated to the email.
      *
      * @throws RealmException If an error occurs during database access.
      * @throws CancellationException If the operation is cancelled.
      */
     @Throws(RealmException::class, CancellationException::class)
-    suspend fun setEmailToken(email: String, authorEmailToken: AuthorEmailToken): Unit = withContext(Dispatchers.IO) {
-        emailTokensController.setEmailToken(email, authorEmailToken.token)
+    suspend fun setEmailToken(email: String, emailToken: String): Unit = withContext(Dispatchers.IO) {
+        emailTokensController.setEmailToken(email, emailToken)
     }
 }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/EmailTokensManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/EmailTokensManager.kt
@@ -19,6 +19,7 @@ package com.infomaniak.multiplatform_swisstransfer.managers
 
 import com.infomaniak.multiplatform_swisstransfer.common.exceptions.RealmException
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.EmailTokensController
+import com.infomaniak.multiplatform_swisstransfer.network.models.upload.response.AuthorEmailToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -45,13 +46,13 @@ class EmailTokensManager(private val emailTokensController: EmailTokensControlle
      * Asynchronously sets the email and it's corresponding token.
      *
      * @param email The validated email.
-     * @param token The valid token associated to the email.
+     * @param authorEmailToken The valid token associated to the email.
      *
      * @throws RealmException If an error occurs during database access.
      * @throws CancellationException If the operation is cancelled.
      */
     @Throws(RealmException::class, CancellationException::class)
-    suspend fun setEmailToken(email: String, token: String): Unit = withContext(Dispatchers.IO) {
-        emailTokensController.setEmailToken(email, token)
+    suspend fun setEmailToken(email: String, authorEmailToken: AuthorEmailToken): Unit = withContext(Dispatchers.IO) {
+        emailTokensController.setEmailToken(email, authorEmailToken.token)
     }
 }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/UploadManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/UploadManager.kt
@@ -110,11 +110,11 @@ class UploadManager(
     }
 
     /**
-     * Stores the email address token in DB for future uses and updates the current uploadSession stored in DB with this new
-     * email address token.
+     * Stores the email address token in DB for future uses and updates the
+     * current uploadSession stored in DB with this new email address token.
      *
-     * @param authorEmail The email to which the [authorEmailToken] is associated.
-     * @param authorEmailToken The token returned by the API that proves that the user owns [authorEmail].
+     * @param authorEmail The email to which the [authorEmailToken] is associated with.
+     * @param authorEmailToken The token returned by the API that proves the user owns [authorEmail].
      *
      * @throws RealmException If an error occurs during database access.
      * @throws CancellationException If the operation is cancelled.
@@ -135,8 +135,8 @@ class UploadManager(
     }
 
     /**
-     * Instantiate a [NewUploadSession] and automatically fills in the author's email token with the one associated with
-     * [authorEmail] from the data base.
+     * Instantiate a [NewUploadSession] and automatically fills in the author's
+     * email token with the one associated with [authorEmail] from the data base.
      *
      * @throws RealmException If an error occurs during database access.
      * @throws CancellationException If the operation is cancelled.

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/UploadManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/UploadManager.kt
@@ -113,19 +113,19 @@ class UploadManager(
      * Stores the email address token in DB for future uses and updates the
      * current uploadSession stored in DB with this new email address token.
      *
-     * @param authorEmail The email to which the [authorEmailToken] is associated with.
-     * @param authorEmailToken The token returned by the API that proves the user owns [authorEmail].
+     * @param authorEmail The email to which the [emailToken] is associated with.
+     * @param emailToken The token returned by the API that proves the user owns [authorEmail].
      *
      * @throws RealmException If an error occurs during database access.
      * @throws CancellationException If the operation is cancelled.
      * @throws NotFoundException If we can't find any upload to update.
      */
     @Throws(RealmException::class, CancellationException::class, NotFoundException::class)
-    suspend fun updateAuthorEmailToken(authorEmail: String, authorEmailToken: AuthorEmailToken) {
-        emailTokensManager.setEmailToken(authorEmail, authorEmailToken)
+    suspend fun updateAuthorEmailToken(authorEmail: String, emailToken: String) {
+        emailTokensManager.setEmailToken(authorEmail, emailToken)
 
         runCatching {
-            uploadController.updateLastUploadSessionAuthorEmailToken(authorEmailToken.token)
+            uploadController.updateLastUploadSessionAuthorEmailToken(emailToken)
         }.onFailure {
             when (it) {
                 is NoSuchElementException -> throw NotFoundException(it.message ?: "")

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/UploadController.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/UploadController.kt
@@ -120,7 +120,7 @@ class UploadController(private val realmProvider: RealmProvider) {
     //endregion
 
     private companion object {
-        //region Query
+        //region Queries
         private fun TypedRealm.getUploadSessionQuery(uuid: String): RealmSingleQuery<UploadSessionDB> {
             return query<UploadSessionDB>("${UploadSessionDB::uuid.name} == '$uuid'").first()
         }

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/UploadController.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/UploadController.kt
@@ -125,7 +125,7 @@ class UploadController(private val realmProvider: RealmProvider) {
             return query<UploadSessionDB>("${UploadSessionDB::uuid.name} == '$uuid'").first()
         }
 
-        fun TypedRealm.getLastUploadQuery(): RealmSingleQuery<UploadSessionDB> {
+        private fun TypedRealm.getLastUploadQuery(): RealmSingleQuery<UploadSessionDB> {
             return query<UploadSessionDB>().first()
         }
         //endregion

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/UploadController.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/UploadController.kt
@@ -50,7 +50,7 @@ class UploadController(private val realmProvider: RealmProvider) {
 
     @Throws(RealmException::class)
     fun getLastUpload(): UploadSession? = runThrowingRealm {
-        return getUploadsQuery().first().find()
+        return realm.getLastUploadQuery().find()
     }
 
     @Throws(RealmException::class)
@@ -97,6 +97,14 @@ class UploadController(private val realmProvider: RealmProvider) {
         }
     }
 
+    @Throws(RealmException::class, CancellationException::class, NoSuchElementException::class)
+    suspend fun updateLastUploadSessionAuthorEmailToken(authorToken: String) {
+        realm.write {
+            val lastUpload = getLastUploadQuery().find() ?: throw NoSuchElementException("No uploadSession found in DB")
+            lastUpload.authorEmailToken = authorToken
+        }
+    }
+
     @Throws(RealmException::class, CancellationException::class)
     suspend fun removeData() = runThrowingRealm {
         realm.write { deleteAll() }
@@ -115,6 +123,10 @@ class UploadController(private val realmProvider: RealmProvider) {
         //region Query
         private fun TypedRealm.getUploadSessionQuery(uuid: String): RealmSingleQuery<UploadSessionDB> {
             return query<UploadSessionDB>("${UploadSessionDB::uuid.name} == '$uuid'").first()
+        }
+
+        fun TypedRealm.getLastUploadQuery(): RealmSingleQuery<UploadSessionDB> {
+            return query<UploadSessionDB>().first()
         }
         //endregion
     }


### PR DESCRIPTION
Refactors some of the logic to automatically read the author token in the data base. Also expose a signature to update the token of the last UploadSession present in the data base 