### PR TITLE
feat: Add Download manager id for Android

### DIFF
--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
@@ -98,6 +98,23 @@ class TransferManager internal constructor(
     }
 
     /**
+     * Designed to keep a reference to the id from Android's DownloadManager.
+     */
+    suspend fun writeDownloadManagerId(
+        transferUUID: String,
+        uniqueDownloadManagerId: Long
+    ) {
+        transferController.writeDownloadManagerId(transferUUID, uniqueDownloadManagerId)
+    }
+
+    /**
+     * Gives the id to retrieve a previous download assigned to Android's DownloadManager.
+     */
+    suspend fun readDownloadManagerId(transferUUID: String): Long? {
+        return transferController.readDownloadManagerId(transferUUID)
+    }
+
+    /**
      * Update the local transfer with remote api
      *
      * @throws RealmException An error has occurred with realm database

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
@@ -102,7 +102,7 @@ class TransferManager internal constructor(
      */
     suspend fun writeDownloadManagerId(
         transferUUID: String,
-        uniqueDownloadManagerId: Long
+        uniqueDownloadManagerId: Long?
     ) {
         transferController.writeDownloadManagerId(transferUUID, uniqueDownloadManagerId)
     }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
@@ -102,16 +102,17 @@ class TransferManager internal constructor(
      */
     suspend fun writeDownloadManagerId(
         transferUUID: String,
+        fileUid: String?,
         uniqueDownloadManagerId: Long?
     ) {
-        transferController.writeDownloadManagerId(transferUUID, uniqueDownloadManagerId)
+        transferController.writeDownloadManagerId(transferUUID, fileUid, uniqueDownloadManagerId)
     }
 
     /**
      * Gives the id to retrieve a previous download assigned to Android's DownloadManager.
      */
-    suspend fun readDownloadManagerId(transferUUID: String): Long? {
-        return transferController.readDownloadManagerId(transferUUID)
+    suspend fun readDownloadManagerId(transferUUID: String, fileUid: String?): Long? {
+        return transferController.readDownloadManagerId(transferUUID, fileUid)
     }
 
     /**

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
@@ -20,6 +20,7 @@ package com.infomaniak.multiplatform_swisstransfer.database
 import com.infomaniak.multiplatform_swisstransfer.database.models.appSettings.AppSettingsDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.appSettings.EmailTokenDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.ContainerDB
+import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.DownloadManagerUniqueId
 import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.FileDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.TransferDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.upload.RemoteUploadFileDB
@@ -97,7 +98,7 @@ class RealmProvider(private val loadDataInMemory: Boolean = false) {
         .build()
 
     private fun realmTransfersConfiguration(userId: Int) = RealmConfiguration
-        .Builder(schema = setOf(TransferDB::class, ContainerDB::class, FileDB::class))
+        .Builder(schema = setOf(TransferDB::class, ContainerDB::class, FileDB::class, DownloadManagerUniqueId::class))
         .name(transferRealmName(userId))
         .deleteRealmDataIfNeeded()
         .loadDataInMemoryIfNeeded()

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
@@ -20,7 +20,7 @@ package com.infomaniak.multiplatform_swisstransfer.database
 import com.infomaniak.multiplatform_swisstransfer.database.models.appSettings.AppSettingsDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.appSettings.EmailTokenDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.ContainerDB
-import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.DownloadManagerUniqueId
+import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.DownloadManagerRef
 import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.FileDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.transfers.TransferDB
 import com.infomaniak.multiplatform_swisstransfer.database.models.upload.RemoteUploadFileDB
@@ -98,7 +98,7 @@ class RealmProvider(private val loadDataInMemory: Boolean = false) {
         .build()
 
     private fun realmTransfersConfiguration(userId: Int) = RealmConfiguration
-        .Builder(schema = setOf(TransferDB::class, ContainerDB::class, FileDB::class, DownloadManagerUniqueId::class))
+        .Builder(schema = setOf(TransferDB::class, ContainerDB::class, FileDB::class, DownloadManagerRef::class))
         .name(transferRealmName(userId))
         .deleteRealmDataIfNeeded()
         .loadDataInMemoryIfNeeded()

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/TransferController.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/TransferController.kt
@@ -168,8 +168,8 @@ class TransferController(private val realmProvider: RealmProvider) {
         private fun getDownloadManagerIdsQuery(
             realm: TypedRealm,
             transferUUID: String
-        ): RealmSingleQuery<DownloadManagerRef> {
-            return realm.query<DownloadManagerRef>("${DownloadManagerRef::transferUUID.name} == '$transferUUID'").first()
+        ): RealmResults<DownloadManagerRef> {
+            return realm.query<DownloadManagerRef>("${DownloadManagerRef::transferUUID.name} == '$transferUUID'").find()
         }
 
         private fun getDownloadManagerIdQuery(

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/TransferController.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/TransferController.kt
@@ -150,7 +150,7 @@ class TransferController(private val realmProvider: RealmProvider) {
         private const val DAYS_SINCE_EXPIRATION = 15
 
         private fun getDownloadManagerIdQuery(realm: Realm, transferUUID: String): RealmSingleQuery<DownloadManagerUniqueId> {
-            return realm.query<DownloadManagerUniqueId>("${DownloadManagerUniqueId::transferUUID} == '$transferUUID'").first()
+            return realm.query<DownloadManagerUniqueId>("${DownloadManagerUniqueId::transferUUID.name} == '$transferUUID'").first()
         }
 
         private fun getTransferQuery(realm: Realm, linkUUID: String): RealmSingleQuery<TransferDB> {

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/models/transfers/DownloadManagerRef.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/models/transfers/DownloadManagerRef.kt
@@ -20,11 +20,32 @@ package com.infomaniak.multiplatform_swisstransfer.database.models.transfers
 import io.realm.kotlin.types.RealmObject
 import io.realm.kotlin.types.annotations.PrimaryKey
 
-class DownloadManagerUniqueId(
+class DownloadManagerRef private constructor(
     @PrimaryKey
+    var id: String,
     var transferUUID: String,
-    var id: Long,
+    @Suppress("unused") // We prefer to keep it in the database.
+    var fileUid: String?,
+    var downloadManagerUniqueId: Long,
 ) : RealmObject {
+
+    constructor(
+        transferUUID: String,
+        fileUid: String?,
+        downloadManagerUniqueId: Long,
+    ) : this(
+        id = buildPrimaryKeyForRealm(transferUUID, fileUid),
+        transferUUID = transferUUID,
+        fileUid = fileUid,
+        downloadManagerUniqueId = downloadManagerUniqueId
+    )
+
     @Suppress("unused") // Kept for Realm
-    constructor() : this("", 0)
+    constructor() : this(id = "", transferUUID = "", fileUid = null, downloadManagerUniqueId = 0)
+
+    companion object {
+        fun buildPrimaryKeyForRealm(transferUUID: String, fileUid: String?): String {
+            return if (fileUid == null) transferUUID else "$transferUUID $fileUid"
+        }
+    }
 }

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/models/transfers/DownloadManagerUniqueId.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/models/transfers/DownloadManagerUniqueId.kt
@@ -1,0 +1,30 @@
+/*
+ * Infomaniak SwissTransfer - Multiplatform
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.multiplatform_swisstransfer.database.models.transfers
+
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
+
+class DownloadManagerUniqueId(
+    @PrimaryKey
+    var transferUUID: String,
+    var id: Long,
+) : RealmObject {
+    @Suppress("unused") // Kept for Realm
+    constructor() : this("", 0)
+}

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/DownloadManagerIdStorageTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/DownloadManagerIdStorageTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Infomaniak SwissTransfer - Multiplatform
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.multiplatform_swisstransfer.database
+
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.File
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.Transfer
+import com.infomaniak.multiplatform_swisstransfer.common.models.TransferDirection
+import com.infomaniak.multiplatform_swisstransfer.database.controllers.TransferController
+import com.infomaniak.multiplatform_swisstransfer.database.dataset.DummyTransfer
+import com.infomaniak.multiplatform_swisstransfer.database.extensions.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.LazyThreadSafetyMode.NONE
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class DownloadManagerIdStorageTest {
+
+    private val realmProvider: RealmProvider by lazy(NONE) {
+        RealmProvider(loadDataInMemory = true).apply { openTransfersDb(userId = 0) }
+    }
+    private val transferController: TransferController by lazy(NONE) {
+        TransferController(realmProvider)
+    }
+
+    @AfterTest
+    fun tearDown() = runTest {
+        transferController.removeData()
+        realmProvider.closeTransfersDb()
+    }
+
+    private val downloadManagerIds = object {
+        private var lastId: Long = 0L
+        val refFirstFile = ++lastId
+        val refSecondFile = ++lastId
+        val refZip = ++lastId
+        val firstFile = ++lastId
+        val secondFile = ++lastId
+        val zip = ++lastId
+    }
+
+    private suspend fun prepareReferenceTransfer(referenceTransfer: Transfer) {
+        val file1 = referenceTransfer.container!!.files[0]
+        val file2 = referenceTransfer.container!!.files[1]
+        writeDlManagerId(
+            transfer = referenceTransfer,
+            file = file1,
+            uniqueId = downloadManagerIds.refFirstFile
+        )
+        writeDlManagerId(
+            transfer = referenceTransfer,
+            file = file2,
+            uniqueId = downloadManagerIds.refSecondFile
+        )
+        writeDlManagerId(
+            transfer = referenceTransfer,
+            file = null,
+            uniqueId = downloadManagerIds.refZip
+        )
+    }
+
+    private suspend fun checkReferenceWasUnchanged(referenceTransfer: Transfer) {
+        val file1 = referenceTransfer.container!!.files[0]
+        val file2 = referenceTransfer.container!!.files[1]
+        readDlManagerId(referenceTransfer, file1) shouldBe downloadManagerIds.refFirstFile
+        readDlManagerId(referenceTransfer, file2) shouldBe downloadManagerIds.refSecondFile
+        readDlManagerId(referenceTransfer, file = null) shouldBe downloadManagerIds.refZip
+    }
+
+    @Test
+    fun checkItAll() = runTest {
+        val targetTransfer = DummyTransfer.expired
+        /** Will be used to prove operations on `targetTransfer` don't affect other transfers. */
+        val referenceTransfer = DummyTransfer.notExpired
+        transferController.upsert(referenceTransfer, TransferDirection.RECEIVED, password = null)
+        transferController.upsert(targetTransfer, TransferDirection.RECEIVED, password = null)
+
+        prepareReferenceTransfer(referenceTransfer)
+
+        run {
+            val file1 = targetTransfer.container!!.files[0]
+            val file2 = targetTransfer.container!!.files[1]
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = downloadManagerIds.firstFile)
+            writeDlManagerId(transfer = targetTransfer, file = file2, uniqueId = downloadManagerIds.secondFile)
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = downloadManagerIds.zip)
+
+            // Check what we inserted is stored properly.
+            readDlManagerId(targetTransfer, file1) shouldBe downloadManagerIds.firstFile
+            readDlManagerId(targetTransfer, file2) shouldBe downloadManagerIds.secondFile
+            readDlManagerId(targetTransfer, file = null) shouldBe downloadManagerIds.zip
+
+            // Check removing file1's DL manager id removes only file1's DL manager id.
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = null)
+            readDlManagerId(targetTransfer, file1) shouldBe null
+            readDlManagerId(targetTransfer, file2) shouldBe downloadManagerIds.secondFile
+            readDlManagerId(targetTransfer, file = null) shouldBe downloadManagerIds.zip
+
+            // Check removing the zip DL manager id removes only the zip DL manager id.
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = null)
+            readDlManagerId(targetTransfer, file1) shouldBe null
+            readDlManagerId(targetTransfer, file2) shouldBe downloadManagerIds.secondFile
+            readDlManagerId(targetTransfer, file = null) shouldBe null
+
+            // Put back DL manager ids prior to subsequent checks.
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = downloadManagerIds.firstFile)
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = downloadManagerIds.zip)
+            // Check deleting the transfer deletes all related DL manager ids.
+            transferController.deleteTransfer(targetTransfer.linkUUID)
+            readDlManagerId(targetTransfer, file1) shouldBe null
+            readDlManagerId(targetTransfer, file2) shouldBe null
+            readDlManagerId(targetTransfer, file = null) shouldBe null
+
+            // Check deleting expired transfers deletes their related DL manager ids.
+            transferController.upsert(targetTransfer, TransferDirection.RECEIVED, password = null)
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = downloadManagerIds.firstFile)
+            writeDlManagerId(transfer = targetTransfer, file = file2, uniqueId = downloadManagerIds.secondFile)
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = downloadManagerIds.zip)
+            transferController.deleteExpiredTransfers()
+        }
+
+        checkReferenceWasUnchanged(referenceTransfer)
+    }
+
+    private suspend fun readDlManagerId(transfer: Transfer, file: File?): Long? {
+        return transferController.readDownloadManagerId(transferUUID = transfer.linkUUID, fileUid = file?.uuid)
+    }
+
+    private suspend fun writeDlManagerId(transfer: Transfer, file: File?, uniqueId: Long?) {
+        transferController.writeDownloadManagerId(
+            transferUUID = transfer.linkUUID,
+            fileUid = file?.uuid,
+            uniqueDownloadManagerId = uniqueId
+        )
+    }
+}

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/TransferControllerTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/TransferControllerTest.kt
@@ -108,8 +108,16 @@ class TransferControllerTest {
         transferController.deleteExpiredTransfers()
 
         val transfers = transferController.getTransfers()
-        assertEquals(transfers.count(), 1, "The transfers table should contain only 1 transfer")
-        assertEquals(transfers.first().linkUUID, DummyTransfer.notExpired.linkUUID, "The remaining transfer should be `transfer2`")
+        assertEquals(
+            expected = 1,
+            actual = transfers.count(),
+            message = "The transfers table should contain only 1 transfer"
+        )
+        assertEquals(
+            expected = DummyTransfer.notExpired.linkUUID,
+            actual = transfers.first().linkUUID,
+            message = "The remaining transfer should be `notExpired`"
+        )
     }
 
     @Test

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/TransferControllerTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/TransferControllerTest.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.multiplatform_swisstransfer.database
 
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.File
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.Transfer
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferDirection
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferStatus
@@ -102,14 +103,111 @@ class TransferControllerTest {
     @Test
     fun canDeleteExpiredTransfers() = runTest {
 
-        transferController.upsert(DummyTransfer.transfer1, TransferDirection.SENT, password = null)
-        transferController.upsert(DummyTransfer.transfer2, TransferDirection.RECEIVED, password = null)
+        transferController.upsert(DummyTransfer.expired, TransferDirection.SENT, password = null)
+        transferController.upsert(DummyTransfer.notExpired, TransferDirection.RECEIVED, password = null)
 
         transferController.deleteExpiredTransfers()
 
         val transfers = transferController.getTransfers()
         assertEquals(transfers.count(), 1, "The transfers table should contain only 1 transfer")
-        assertEquals(transfers.first().linkUUID, DummyTransfer.transfer2.linkUUID, "The remaining transfer should be `transfer2`")
+        assertEquals(transfers.first().linkUUID, DummyTransfer.notExpired.linkUUID, "The remaining transfer should be `transfer2`")
+    }
+
+    @Test
+    fun downloadManagerId() = runTest {
+        val targetTransfer = DummyTransfer.expired
+        /** Will be used to prove operations on `targetTransfer` don't affect other transfers. */
+        val referenceTransfer = DummyTransfer.notExpired
+        transferController.upsert(referenceTransfer, TransferDirection.RECEIVED, password = null)
+        transferController.upsert(targetTransfer, TransferDirection.RECEIVED, password = null)
+
+        val downloadManagerIds = object {
+            private var lastId: Long = 0L
+            val refFirstFile = ++lastId
+            val refSecondFile = ++lastId
+            val refZip = ++lastId
+            val firstFile = ++lastId
+            val secondFile = ++lastId
+            val zip = ++lastId
+        }
+        run prepareReferenceTransfer@{
+            val transferUUID = referenceTransfer.linkUUID
+            val file1 = referenceTransfer.container!!.files[0]
+            val file2 = referenceTransfer.container!!.files[1]
+            transferController.writeDownloadManagerId(
+                transferUUID = transferUUID,
+                fileUid = file1.uuid,
+                uniqueDownloadManagerId = downloadManagerIds.refFirstFile
+            )
+            transferController.writeDownloadManagerId(
+                transferUUID = transferUUID,
+                fileUid = file2.uuid,
+                uniqueDownloadManagerId = downloadManagerIds.refSecondFile
+            )
+            transferController.writeDownloadManagerId(
+                transferUUID = transferUUID,
+                fileUid = null,
+                uniqueDownloadManagerId = downloadManagerIds.refZip
+            )
+        }
+        suspend fun readDlManagerId(transfer: Transfer, file: File?): Long? {
+            return transferController.readDownloadManagerId(transferUUID = transfer.linkUUID, fileUid = file?.uuid)
+        }
+
+        suspend fun writeDlManagerId(transfer: Transfer, file: File?, uniqueId: Long?) {
+            transferController.writeDownloadManagerId(
+                transferUUID = transfer.linkUUID,
+                fileUid = file?.uuid,
+                uniqueDownloadManagerId = uniqueId
+            )
+        }
+
+        run {
+            val file1 = targetTransfer.container!!.files[0]
+            val file2 = targetTransfer.container!!.files[1]
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = downloadManagerIds.firstFile)
+            writeDlManagerId(transfer = targetTransfer, file = file2, uniqueId = downloadManagerIds.secondFile)
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = downloadManagerIds.zip)
+
+            readDlManagerId(targetTransfer, file1) shouldBe downloadManagerIds.firstFile
+            readDlManagerId(targetTransfer, file2) shouldBe downloadManagerIds.secondFile
+            readDlManagerId(targetTransfer, file = null) shouldBe downloadManagerIds.zip
+
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = null)
+            readDlManagerId(targetTransfer, file1) shouldBe null
+            readDlManagerId(targetTransfer, file2) shouldBe downloadManagerIds.secondFile
+            readDlManagerId(targetTransfer, file = null) shouldBe downloadManagerIds.zip
+
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = null)
+            readDlManagerId(targetTransfer, file1) shouldBe null
+            readDlManagerId(targetTransfer, file2) shouldBe downloadManagerIds.secondFile
+            readDlManagerId(targetTransfer, file = null) shouldBe null
+
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = downloadManagerIds.firstFile)
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = downloadManagerIds.zip)
+            transferController.deleteTransfer(targetTransfer.linkUUID)
+            readDlManagerId(targetTransfer, file1) shouldBe null
+            readDlManagerId(targetTransfer, file2) shouldBe null
+            readDlManagerId(targetTransfer, file = null) shouldBe null
+
+            transferController.upsert(targetTransfer, TransferDirection.RECEIVED, password = null)
+            writeDlManagerId(transfer = targetTransfer, file = file1, uniqueId = downloadManagerIds.firstFile)
+            writeDlManagerId(transfer = targetTransfer, file = file2, uniqueId = downloadManagerIds.secondFile)
+            writeDlManagerId(transfer = targetTransfer, file = null, uniqueId = downloadManagerIds.zip)
+            transferController.deleteExpiredTransfers()
+        }
+
+        run checkReferenceWasUnchanged@{
+            val file1 = referenceTransfer.container!!.files[0]
+            val file2 = referenceTransfer.container!!.files[1]
+            readDlManagerId(referenceTransfer, file1) shouldBe downloadManagerIds.refFirstFile
+            readDlManagerId(referenceTransfer, file2) shouldBe downloadManagerIds.refSecondFile
+            readDlManagerId(referenceTransfer, file = null) shouldBe downloadManagerIds.refZip
+        }
+    }
+
+    private inline infix fun <T> T.shouldBe(expected: T) {
+        assertEquals(expected = expected, actual = this)
     }
 
     @Test

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/dataset/DummyTransfer.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/dataset/DummyTransfer.kt
@@ -21,6 +21,9 @@ import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.Co
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.File
 import com.infomaniak.multiplatform_swisstransfer.common.interfaces.transfers.Transfer
 import com.infomaniak.multiplatform_swisstransfer.common.models.TransferStatus
+import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 
 object DummyTransfer {
 
@@ -38,12 +41,18 @@ object DummyTransfer {
         override var swiftVersion: Int = 0
         override var downloadLimit: Int = 0
         override var source: String = "source"
-        override var files: List<File> = emptyList()
+        override var files: List<File> = listOf(
+            createDummyFile(containerUUID = uuid, fileName = "cat no no.gif", mimeType = "image/gif"),
+            createDummyFile(containerUUID = uuid, fileName = "cat vibe.gif", mimeType = "image/gif"),
+        )
     }
 
     val container2 = object : Container by container1 {
         override val uuid: String = "transfer2container"
     }
+
+    val expired: Transfer
+    val notExpired: Transfer
 
     val transfer1 = object : Transfer {
         override var linkUUID: String = "transferLinkUUID1"
@@ -66,6 +75,32 @@ object DummyTransfer {
         override val transferStatus: TransferStatus = TransferStatus.WAIT_VIRUS_CHECK
     }
 
+    init {
+        expired = transfer1
+        notExpired = transfer2
+    }
+
     val transfers = listOf(transfer1, transfer2)
+
+    private fun createDummyFile(
+        containerUUID: String,
+        fileName: String,
+        mimeType: String? = null,
+    ): File = object : File {
+        override val containerUUID: String = containerUUID
+        override val uuid: String = "$fileName|whatever"
+        override val fileName: String = fileName
+        override val fileSizeInBytes: Long = 10_000_000L
+        override val downloadCounter: Int = 0
+        override val createdDateTimestamp: Long = (Clock.System.now() - 1.hours).epochSeconds
+        override val expiredDateTimestamp: Long = (Clock.System.now() + 7.days).epochSeconds
+        override val eVirus: String = ""
+        override val deletedDate: String? = null
+        override val mimeType: String? = mimeType
+        override val receivedSizeInBytes: Long = fileSizeInBytes
+        override val path: String? = null
+        override val thumbnailPath: String? = null
+
+    }
 
 }

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/extensions/Assertions.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/extensions/Assertions.kt
@@ -1,0 +1,24 @@
+/*
+ * Infomaniak SwissTransfer - Multiplatform
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.multiplatform_swisstransfer.database.extensions
+
+import kotlin.test.assertEquals
+
+inline infix fun <T> T.shouldBe(expected: T) {
+    assertEquals(expected = expected, actual = this)
+}


### PR DESCRIPTION
This will allow the Android app to keep track of any download handed to `DownloadManager` beyond the process lifecycle.