### PR TITLE
chore: Refactor API properties and remove unused

### DIFF
--- a/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/models/transfer/ContainerApi.kt
+++ b/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/models/transfer/ContainerApi.kt
@@ -47,8 +47,6 @@ data class ContainerApi(
     override var deletedDateTimestamp: Long? = null,
     override var swiftVersion: Int = 0,
     override var downloadLimit: Int,
-    override var source: String = "ST",
-    // @SerialName("WSUser") // TODO: What's this ?
-    // var wsUser: JsonElement? = null
+    override var source: String = "MOBILE", //ST=Webapp, EXT=Chrome extension to be removed before v2, WS= Workspace Mail
     override var files: List<FileApi>,
 ) : Container


### PR DESCRIPTION
After some discussion with the back office, it turns out that we have some fields that we don't need or won't use.
But you never know, so here we add more information on properties that were incomprehensible and delete when we deem them really useless.