### PR TITLE
fix: Update the transfer status if needed

### DIFF
--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/TransferController.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/controllers/TransferController.kt
@@ -126,6 +126,9 @@ class TransferController(private val realmProvider: RealmProvider) {
                 it.downloadCounterCredit = transfer.downloadCounterCredit
                 it.isMailSent = transfer.isMailSent
                 it.downloadHost = transfer.downloadHost
+                if (it.transferStatus != transfer.transferStatus) {
+                    it.transferStatus = transfer.transferStatus ?: TransferStatus.READY
+                }
             }
         }
     }


### PR DESCRIPTION
Since the last release, transfers no longer have the correct status when updated with the api.
In the latest update, we make the difference between `insert` and `update` of a transfer, knowing that when inserting, we define a transfer status, but this is never updated when `updating`.