### PR TITLE
fix: Make the loadUser threadSafe method

### DIFF
--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/AccountManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/AccountManager.kt
@@ -44,6 +44,8 @@ class AccountManager internal constructor(
 ) {
 
     private val mutex = Mutex()
+
+    // We store the currentUserId to avoid creating database instances when it's the same user
     private var currentUserId: Int? = null
 
     /**

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/AccountManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/AccountManager.kt
@@ -23,6 +23,8 @@ import com.infomaniak.multiplatform_swisstransfer.database.controllers.AppSettin
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.TransferController
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.UploadController
 import com.infomaniak.multiplatform_swisstransfer.utils.EmailLanguageUtils
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -41,13 +43,17 @@ class AccountManager internal constructor(
     private val realmProvider: RealmProvider,
 ) {
 
+    private val mutex = Mutex()
+
     /**
      * Loads the default User account and initializes Realm Transfers for the default UserID defined in Constants.
      */
     @Throws(RealmException::class, CancellationException::class)
     suspend fun loadUser(userId: Int) {
-        appSettingsController.initAppSettings(emailLanguageUtils.getEmailLanguageFromLocal())
-        realmProvider.openTransfersDb(userId)
+        mutex.withLock {
+            appSettingsController.initAppSettings(emailLanguageUtils.getEmailLanguageFromLocal())
+            realmProvider.openTransfersDb(userId)
+        }
     }
 
     /**

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/AccountManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/AccountManager.kt
@@ -44,6 +44,7 @@ class AccountManager internal constructor(
 ) {
 
     private val mutex = Mutex()
+    private var currentUserId: Int? = null
 
     /**
      * Loads the default User account and initializes Realm Transfers for the default UserID defined in Constants.
@@ -51,8 +52,11 @@ class AccountManager internal constructor(
     @Throws(RealmException::class, CancellationException::class)
     suspend fun loadUser(userId: Int) {
         mutex.withLock {
-            appSettingsController.initAppSettings(emailLanguageUtils.getEmailLanguageFromLocal())
-            realmProvider.openTransfersDb(userId)
+            if (currentUserId != userId) {
+                appSettingsController.initAppSettings(emailLanguageUtils.getEmailLanguageFromLocal())
+                realmProvider.openTransfersDb(userId)
+                currentUserId = userId
+            }
         }
     }
 

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmMigrations.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmMigrations.kt
@@ -35,7 +35,7 @@ val TRANSFERS_MIGRATION = AutomaticSchemaMigration { migrationContext ->
     migrationContext.renameEnumValueAfterFirstMigration()
 }
 
-// Migrate from version #1
+// Migrate to version #2
 private fun MigrationContext.renameEnumValueAfterFirstMigration() {
 
     if (oldRealm.schemaVersion() <= 1L) {

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
@@ -30,7 +30,6 @@ import com.infomaniak.multiplatform_swisstransfer.database.models.upload.UploadS
 import com.infomaniak.multiplatform_swisstransfer.database.utils.RealmUtils.runThrowingRealm
 import io.realm.kotlin.Realm
 import io.realm.kotlin.RealmConfiguration
-import io.realm.kotlin.migration.AutomaticSchemaMigration
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll

--- a/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
+++ b/STDatabase/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProvider.kt
@@ -39,10 +39,14 @@ class RealmProvider(private val databaseRootDirectory: String? = null, private v
 
     val appSettings by lazy { Realm.open(realmAppSettingsConfiguration) }
     val uploads by lazy { Realm.open(realmUploadDBConfiguration) }
-    private val transfersAsync = CompletableDeferred<Realm>()
+    internal var transfersAsync = CompletableDeferred<Realm>()
     private suspend fun transfers(): Realm = transfersAsync.await()
 
-    fun openTransfersDb(userId: Int) {
+    suspend fun openTransfersDb(userId: Int) {
+        if (!transfersAsync.isActive) {
+            closeTransfersDb()
+            transfersAsync = CompletableDeferred()
+        }
         transfersAsync.complete(Realm.open(realmTransfersConfiguration(userId)))
     }
 

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/DownloadManagerIdStorageTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/DownloadManagerIdStorageTest.kt
@@ -27,15 +27,19 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.LazyThreadSafetyMode.NONE
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 class DownloadManagerIdStorageTest {
 
-    private val realmProvider: RealmProvider by lazy(NONE) {
-        RealmProvider(loadDataInMemory = true).apply { openTransfersDb(userId = 0) }
-    }
+    private lateinit var realmProvider: RealmProvider
     private val transferController: TransferController by lazy(NONE) {
         TransferController(realmProvider)
+    }
+
+    @BeforeTest
+    fun setup() = runTest {
+        realmProvider = RealmProvider(loadDataInMemory = true).apply { openTransfersDb(userId = 0) }
     }
 
     @AfterTest

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProviderTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProviderTest.kt
@@ -40,20 +40,20 @@ class RealmProviderTest {
     @Test
     fun canSwitchUserByClosingPreviousUser() = runTest {
         // Login user
-        realmProvider.openTransfersDb(1)
+        realmProvider.openTransfersDb(userId = 1)
         val previousRealm = realmProvider.transfersAsync.await()
         val oldTransferJob = realmProvider.transfersAsync.job
         assertEquals(true, realmProvider.transfersAsync.isCompleted)
 
         // Switch user account with another user
-        realmProvider.openTransfersDb(2)
+        realmProvider.openTransfersDb(userId = 2)
         assertNotEquals(oldTransferJob, realmProvider.transfersAsync.job, "The new switched account must have its own job")
         assertTrue(previousRealm.isClosed(), "The realm of the previous user must be closed")
     }
 
     @Test
     fun canCloseTransfersDb() = runTest {
-        realmProvider.openTransfersDb(1)
+        realmProvider.openTransfersDb(userId = 1)
         val transfersRealm = realmProvider.transfersAsync.await()
         assertFalse(transfersRealm.isClosed())
 

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProviderTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/RealmProviderTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Infomaniak SwissTransfer - Multiplatform
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.multiplatform_swisstransfer.database
+
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+class RealmProviderTest {
+
+    private lateinit var realmProvider: RealmProvider
+
+    @BeforeTest
+    fun setup() = runTest {
+        realmProvider = RealmProvider(loadDataInMemory = true).apply { openTransfersDb(userId = 0) }
+    }
+
+    @AfterTest
+    fun tearDown() = runTest {
+        if (realmProvider.transfersAsync.isCompleted) {
+            realmProvider.closeTransfersDb()
+        }
+    }
+
+    @Test
+    fun canSwitchUserByClosingPreviousUser() = runTest {
+        // Login user
+        realmProvider.openTransfersDb(1)
+        val previousRealm = realmProvider.transfersAsync.await()
+        val oldTransferJob = realmProvider.transfersAsync.job
+        assertEquals(true, realmProvider.transfersAsync.isCompleted)
+
+        // Switch user account with another user
+        realmProvider.openTransfersDb(2)
+        assertNotEquals(oldTransferJob, realmProvider.transfersAsync.job, "The new switched account must have its own job")
+        assertTrue(previousRealm.isClosed(), "The realm of the previous user must be closed")
+    }
+
+    @Test
+    fun canCloseTransfersDb() = runTest {
+        realmProvider.openTransfersDb(1)
+        val transfersRealm = realmProvider.transfersAsync.await()
+        assertFalse(transfersRealm.isClosed())
+
+        realmProvider.closeTransfersDb()
+        assertTrue(transfersRealm.isClosed())
+    }
+}

--- a/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/TransferControllerTest.kt
+++ b/STDatabase/src/commonTest/kotlin/com/infomaniak/multiplatform_swisstransfer/database/TransferControllerTest.kt
@@ -33,7 +33,7 @@ class TransferControllerTest {
     private lateinit var transferController: TransferController
 
     @BeforeTest
-    fun setup() {
+    fun setup() = runTest {
         realmProvider = RealmProvider(loadDataInMemory = true).apply { openTransfersDb(userId = 0) }
         transferController = TransferController(realmProvider)
     }


### PR DESCRIPTION
Because of a bug on iOS, we realized that the fact that this method is not threadSafa creates a problem during migration, because it causes a realm migration exception.

So now the method is threadSafe, and we've also taken the opportunity to improve the method, because now you can switch accounts while closing the old one, to avoid memory leaks.