### PR TITLE
fix(TransferManager): Throw `DownloadQuotaExceededException` in `TransferManager`

### DIFF
--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
@@ -112,8 +112,6 @@ class TransferManager internal constructor(
 
         coroutineScope {
             transferController.getAllTransfers().forEach { transfer ->
-                val transferDirection = transfer.transferDirection ?: return@forEach
-
                 launch {
                     runCatching {
                         semaphore.withPermit {

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/managers/TransferManager.kt
@@ -113,11 +113,9 @@ class TransferManager internal constructor(
         coroutineScope {
             transferController.getAllTransfers().forEach { transfer ->
                 launch {
-                    runCatching {
-                        semaphore.withPermit {
-                            fetchTransfer(transfer)
-                        }
-                    }.onFailure { exception -> if (exception is CancellationException) throw exception }
+                    semaphore.withPermit {
+                        fetchTransfer(transfer)
+                    }
                 }
             }
         }
@@ -131,9 +129,7 @@ class TransferManager internal constructor(
     @Throws(RealmException::class, CancellationException::class)
     suspend fun fetchWaitingTransfers(): Unit = withContext(Dispatchers.Default) {
         transferController.getNotReadyTransfers().forEach { transfer ->
-            runCatching {
-                fetchTransfer(transfer)
-            }
+            fetchTransfer(transfer)
         }
     }
 
@@ -196,6 +192,7 @@ class TransferManager internal constructor(
                     transfer.linkUUID,
                     TransferStatus.EXPIRED_DATE,
                 )
+                is CancellationException -> throw exception
             }
         }
     }

--- a/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/repositories/TransferRepository.kt
+++ b/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/repositories/TransferRepository.kt
@@ -64,7 +64,7 @@ class TransferRepository internal constructor(private val transferRequest: Trans
     suspend fun getTransferByLinkUUID(linkUUID: String, password: String?): ApiResponse<TransferApi> = runCatching {
         transferRequest.getTransfer(linkUUID, password)
     }.getOrElse { exception ->
-        if (exception is UnexpectedApiErrorFormatException) throw exception.toFetchTransferException() else throw exception
+        throw if (exception is UnexpectedApiErrorFormatException) exception.toFetchTransferException() else exception
     }
 
     @Throws(

--- a/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/repositories/TransferRepository.kt
+++ b/STNetwork/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/network/repositories/TransferRepository.kt
@@ -22,7 +22,6 @@ import com.infomaniak.multiplatform_swisstransfer.common.utils.ApiEnvironment
 import com.infomaniak.multiplatform_swisstransfer.network.ApiClientProvider
 import com.infomaniak.multiplatform_swisstransfer.network.exceptions.ApiException.ApiErrorException
 import com.infomaniak.multiplatform_swisstransfer.network.exceptions.ApiException.UnexpectedApiErrorFormatException
-import com.infomaniak.multiplatform_swisstransfer.network.exceptions.DownloadQuotaExceededException
 import com.infomaniak.multiplatform_swisstransfer.network.exceptions.FetchTransferException.*
 import com.infomaniak.multiplatform_swisstransfer.network.exceptions.FetchTransferException.Companion.toFetchTransferException
 import com.infomaniak.multiplatform_swisstransfer.network.exceptions.NetworkException
@@ -63,9 +62,7 @@ class TransferRepository internal constructor(private val transferRequest: Trans
         WrongPasswordFetchTransferException::class,
     )
     suspend fun getTransferByLinkUUID(linkUUID: String, password: String?): ApiResponse<TransferApi> = runCatching {
-        return@runCatching transferRequest.getTransfer(linkUUID, password).also {
-            it.data?.validateDownloadCounterCreditOrThrow()
-        }
+        transferRequest.getTransfer(linkUUID, password)
     }.getOrElse { exception ->
         if (exception is UnexpectedApiErrorFormatException) throw exception.toFetchTransferException() else throw exception
     }
@@ -79,19 +76,12 @@ class TransferRepository internal constructor(private val transferRequest: Trans
         VirusCheckFetchTransferException::class,
         VirusDetectedFetchTransferException::class,
         ExpiredDateFetchTransferException::class,
-        DownloadQuotaExceededException::class,
         NotFoundFetchTransferException::class,
         PasswordNeededFetchTransferException::class,
         WrongPasswordFetchTransferException::class,
     )
     suspend fun getTransferByUrl(url: String, password: String?): ApiResponse<TransferApi> {
-        return getTransferByLinkUUID(extractUUID(url), password).also {
-            it.data?.validateDownloadCounterCreditOrThrow()
-        }
-    }
-
-    private fun TransferApi.validateDownloadCounterCreditOrThrow() {
-        if (downloadCounterCredit <= 0) throw DownloadQuotaExceededException()
+        return getTransferByLinkUUID(extractUUID(url), password)
     }
 
     @Throws(


### PR DESCRIPTION
Currently the `DownloadQuotaExceededException` is raised in `TransferRepository.kt`.
So the transfer is never updated.