### PR TITLE
feat: Error Report interface

### DIFF
--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
@@ -17,7 +17,7 @@
  */
 package com.infomaniak.multiplatform_swisstransfer.common.interfaces
 
-public enum class SentryLevel {
+public enum class CrashReportLevel {
     DEBUG,
     INFO,
     WARNING,
@@ -25,11 +25,11 @@ public enum class SentryLevel {
     FATAL
 }
 
-public interface SentryInterface {
+public interface CrashReportInterface {
     fun addBreadcrumb(
         message: String,
         category: String,
-        level: SentryLevel,
+        level: CrashReportLevel,
         metadata: Map<String, Any>? = null
     )
 
@@ -44,7 +44,7 @@ public interface SentryInterface {
         message: String,
         context: Map<String, Any>? = null,
         contextKey: String? = null,
-        level: SentryLevel? = null,
+        level: CrashReportLevel? = null,
         extras: Map<String, Any>? = null
     )
 }

--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
@@ -26,6 +26,16 @@ public enum class CrashReportLevel {
 }
 
 public interface CrashReportInterface {
+
+    /**
+     * Adds a breadcrumb to the crash reporting system to provide contextual information
+     * leading up to a potential crash.
+     *
+     * @param message A descriptive message for the breadcrumb, explaining the event or action.
+     * @param category A category string to group related breadcrumbs (e.g., "UI", "Network").
+     * @param level The severity level of the breadcrumb (e.g., info, warning, error).
+     * @param metadata Optional additional metadata providing more context about the event.
+     */
     fun addBreadcrumb(
         message: String,
         category: String,
@@ -33,6 +43,16 @@ public interface CrashReportInterface {
         metadata: Map<String, Any>? = null
     )
 
+    /**
+     * Captures and reports an error to the crash reporting system with optional context
+     * and additional metadata.
+     *
+     * @param error The [Throwable] to be reported.
+     * @param context Optional contextual data to provide more insight into the environment
+     *                or state when the error occurred.
+     * @param contextKey An optional key to identify or categorize the provided context.
+     * @param extras Optional additional metadata to include in the report for debugging purposes.
+     */
     fun capture(
         error: Throwable,
         context: Map<String, Any>? = null,
@@ -40,6 +60,17 @@ public interface CrashReportInterface {
         extras: Map<String, Any>? = null
     )
 
+    /**
+     * Captures a custom message and reports it to the crash reporting system with optional context,
+     * severity level, and additional metadata.
+     *
+     * @param message The custom message to be reported (e.g., an error message or event description).
+     * @param context Optional contextual data that provides additional information about the environment
+     *                or state when the message was logged.
+     * @param contextKey An optional key to categorize or identify the provided context data.
+     * @param level The severity level of the message (e.g., `info`, `warning`, `error`).
+     * @param extras Optional additional metadata to include with the message for debugging purposes.
+     */
     fun capture(
         message: String,
         context: Map<String, Any>? = null,

--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
@@ -47,14 +47,14 @@ public interface CrashReportInterface {
      * and additional metadata.
      *
      * @param error The [Throwable] to be reported.
-     * @param context Optional contextual data to provide more insight into the environment
+     * @param data Optional contextual data to provide more insight into the environment
      *                or state when the error occurred.
-     * @param contextKey An optional key to identify or categorize the provided context.
+     * @param category An optional string to identify or categorize the provided event.
      */
     fun capture(
         error: Throwable,
-        context: Map<String, Any>? = null,
-        contextKey: String? = null
+        data: Map<String, Any>? = null,
+        category: String? = null
     )
 
     /**
@@ -62,15 +62,15 @@ public interface CrashReportInterface {
      * severity level, and additional metadata.
      *
      * @param message The custom message to be reported (e.g., an error message or event description).
-     * @param context Optional contextual data that provides additional information about the environment
+     * @param data Optional contextual data that provides additional information about the environment
      *                or state when the message was logged.
-     * @param contextKey An optional key to categorize or identify the provided context data.
+     * @param category An optional string to categorize or identify the provided event.
      * @param level The severity level of the message (e.g., `info`, `warning`, `error`).
      */
     fun capture(
         message: String,
-        context: Map<String, Any>? = null,
-        contextKey: String? = null,
+        data: Map<String, Any>? = null,
+        category: String? = null,
         level: CrashReportLevel? = null
     )
 }

--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
@@ -26,7 +26,6 @@ public enum class CrashReportLevel {
 }
 
 public interface CrashReportInterface {
-
     /**
      * Adds a breadcrumb to the crash reporting system to provide contextual information
      * leading up to a potential crash.
@@ -34,13 +33,13 @@ public interface CrashReportInterface {
      * @param message A descriptive message for the breadcrumb, explaining the event or action.
      * @param category A category string to group related breadcrumbs (e.g., "UI", "Network").
      * @param level The severity level of the breadcrumb (e.g., info, warning, error).
-     * @param metadata Optional additional metadata providing more context about the event.
+     * @param data Optional additional data providing more context about the event.
      */
     fun addBreadcrumb(
         message: String,
         category: String,
         level: CrashReportLevel,
-        metadata: Map<String, Any>? = null
+        data: Map<String, Any>? = null
     )
 
     /**

--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/CrashReportInterface.kt
@@ -51,13 +51,11 @@ public interface CrashReportInterface {
      * @param context Optional contextual data to provide more insight into the environment
      *                or state when the error occurred.
      * @param contextKey An optional key to identify or categorize the provided context.
-     * @param extras Optional additional metadata to include in the report for debugging purposes.
      */
     fun capture(
         error: Throwable,
         context: Map<String, Any>? = null,
-        contextKey: String? = null,
-        extras: Map<String, Any>? = null
+        contextKey: String? = null
     )
 
     /**
@@ -69,14 +67,12 @@ public interface CrashReportInterface {
      *                or state when the message was logged.
      * @param contextKey An optional key to categorize or identify the provided context data.
      * @param level The severity level of the message (e.g., `info`, `warning`, `error`).
-     * @param extras Optional additional metadata to include with the message for debugging purposes.
      */
     fun capture(
         message: String,
         context: Map<String, Any>? = null,
         contextKey: String? = null,
-        level: CrashReportLevel? = null,
-        extras: Map<String, Any>? = null
+        level: CrashReportLevel? = null
     )
 }
 

--- a/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/SentryInterface.kt
+++ b/STCommon/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/common/interfaces/SentryInterface.kt
@@ -1,0 +1,51 @@
+/*
+ * Infomaniak SwissTransfer - Multiplatform
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.multiplatform_swisstransfer.common.interfaces
+
+public enum class SentryLevel {
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL
+}
+
+public interface SentryInterface {
+    fun addBreadcrumb(
+        message: String,
+        category: String,
+        level: SentryLevel,
+        metadata: Map<String, Any>? = null
+    )
+
+    fun capture(
+        error: Throwable,
+        context: Map<String, Any>? = null,
+        contextKey: String? = null,
+        extras: Map<String, Any>? = null
+    )
+
+    fun capture(
+        message: String,
+        context: Map<String, Any>? = null,
+        contextKey: String? = null,
+        level: SentryLevel? = null,
+        extras: Map<String, Any>? = null
+    )
+}
+

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.multiplatform_swisstransfer
 
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.SentryInterface
 import com.infomaniak.multiplatform_swisstransfer.common.utils.ApiEnvironment
 import com.infomaniak.multiplatform_swisstransfer.database.RealmProvider
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.*
@@ -37,6 +38,7 @@ import com.infomaniak.multiplatform_swisstransfer.utils.EmailLanguageUtils
  * @property environment Customize client api base url, for example [ApiEnvironment.Prod]
  * @property userAgent Customize client api userAgent.
  * @property databaseRootDirectory Customize root directory for realm, eg. iOS app group container.
+ * @property sentry An abstract Sentry used to log error and add breadcrumbs.
  * @property transferManager A manager used to orchestrate transfer operations.
  * @property appSettingsManager A manager used to orchestrate AppSettings operations.
  * @property accountManager A manager used to orchestrate Accounts operations.
@@ -49,6 +51,7 @@ class SwissTransferInjection(
     private val environment: ApiEnvironment,
     private val userAgent: String,
     private val databaseRootDirectory: String? = null,
+    private val sentry: SentryInterface,
 ) {
 
     private val realmProvider by lazy { RealmProvider(databaseRootDirectory) }

--- a/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
+++ b/STCore/src/commonMain/kotlin/com/infomaniak/multiplatform_swisstransfer/SwissTransferInjection.kt
@@ -17,7 +17,7 @@
  */
 package com.infomaniak.multiplatform_swisstransfer
 
-import com.infomaniak.multiplatform_swisstransfer.common.interfaces.SentryInterface
+import com.infomaniak.multiplatform_swisstransfer.common.interfaces.CrashReportInterface
 import com.infomaniak.multiplatform_swisstransfer.common.utils.ApiEnvironment
 import com.infomaniak.multiplatform_swisstransfer.database.RealmProvider
 import com.infomaniak.multiplatform_swisstransfer.database.controllers.*
@@ -38,7 +38,7 @@ import com.infomaniak.multiplatform_swisstransfer.utils.EmailLanguageUtils
  * @property environment Customize client api base url, for example [ApiEnvironment.Prod]
  * @property userAgent Customize client api userAgent.
  * @property databaseRootDirectory Customize root directory for realm, eg. iOS app group container.
- * @property sentry An abstract Sentry used to log error and add breadcrumbs.
+ * @property crashReport A crash report interface used to report errors and add breadcrumbs.
  * @property transferManager A manager used to orchestrate transfer operations.
  * @property appSettingsManager A manager used to orchestrate AppSettings operations.
  * @property accountManager A manager used to orchestrate Accounts operations.
@@ -51,7 +51,7 @@ class SwissTransferInjection(
     private val environment: ApiEnvironment,
     private val userAgent: String,
     private val databaseRootDirectory: String? = null,
-    private val sentry: SentryInterface,
+    private val crashReport: CrashReportInterface,
 ) {
 
     private val realmProvider by lazy { RealmProvider(databaseRootDirectory) }


### PR DESCRIPTION
#### Abstract

A new interface to abstract `Error reporting` was added.

Now, each OS will be able to pass to `SwissTransferInjection` a `CrashReportInterface` to add breadcrumbs and capture errors within the KMP code.

This approach in simple, yet allows to leverage native code of each platform.